### PR TITLE
Add Python 3.9 compatibility

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,7 +39,7 @@ jobs:
       # Run all matrix jobs even if one of them fails.
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-latest, windows-latest]
         pydantic: ['2.9.2']
         # Test pydantic at lower boundary of requirement compatibility spec.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This library aims to make common data analysis and workflow automation tasks as 
 
 ## Install
 
-The currently supported Python versions for `pyodk` are 3.10 to 3.13 (the primary development version is 3.12). If this is different from the version you use for other projects, consider using [`pyenv`](https://github.com/pyenv/pyenv) to manage multiple versions of Python.
+The currently supported Python versions for `pyodk` are 3.9 to 3.13 (the primary development version is 3.12). If this is different from the version you use for other projects, consider using [`pyenv`](https://github.com/pyenv/pyenv) to manage multiple versions of Python.
 
 The currently supported Central version is v2025.1.4. Newer or older Central versions will likely work too, but convenience (non-HTTP) methods assume this version. If you see a 404 error or another server error, please verify the version of your Central server.
 

--- a/pyodk/_endpoints/auth.py
+++ b/pyodk/_endpoints/auth.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from pyodk._utils import config
 from pyodk.errors import PyODKError
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(self, session: "Session", cache_path: str | None = None) -> None:
+    def __init__(self, session: "Session", cache_path: Optional[str] = None) -> None:
         self.session: Session = session
         self.cache_path: str = cache_path
 

--- a/pyodk/_endpoints/comments.py
+++ b/pyodk/_endpoints/comments.py
@@ -6,6 +6,7 @@ from pyodk._endpoints.bases import Model, Service
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
+from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ class Comment(Model):
     createdAt: datetime
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class URLs:
     list: str = "projects/{project_id}/forms/{form_id}/submissions/{instance_id}/comments"
     post: str = "projects/{project_id}/forms/{form_id}/submissions/{instance_id}/comments"
@@ -34,22 +35,22 @@ class CommentService(Service):
     def __init__(
         self,
         session: Session,
-        default_project_id: int | None = None,
-        default_form_id: str | None = None,
-        default_instance_id: str | None = None,
+        default_project_id: Optional[int] = None,
+        default_form_id: Optional[str] = None,
+        default_instance_id: Optional[str] = None,
         urls: URLs = None,
     ):
         self.urls: URLs = urls if urls is not None else URLs()
         self.session: Session = session
-        self.default_project_id: int | None = default_project_id
-        self.default_form_id: str | None = default_form_id
-        self.default_instance_id: str | None = default_instance_id
+        self.default_project_id: Optional[int] = default_project_id
+        self.default_form_id: Optional[str] = default_form_id
+        self.default_instance_id: Optional[str] = default_instance_id
 
     def list(
         self,
-        form_id: str | None = None,
-        project_id: int | None = None,
-        instance_id: str | None = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
+        instance_id: Optional[str] = None,
     ) -> list[Comment]:
         """
         Read all Comment details.
@@ -79,9 +80,9 @@ class CommentService(Service):
     def post(
         self,
         comment: str,
-        project_id: int | None = None,
-        form_id: str | None = None,
-        instance_id: str | None = None,
+        project_id: Optional[int] = None,
+        form_id: Optional[str] = None,
+        instance_id: Optional[str] = None,
     ) -> Comment:
         """
         Create a Comment.

--- a/pyodk/_endpoints/entities.py
+++ b/pyodk/_endpoints/entities.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional, Union
 from uuid import uuid4
 
 from pyodk.__version__ import __version__
@@ -50,9 +50,9 @@ class CurrentVersion(Model):
     creatorId: int
     userAgent: str
     version: int
-    data: dict | None = None
-    baseVersion: int | None = None
-    conflictingProperties: list[str] | None = None
+    data: Optional[dict] = None
+    baseVersion: Optional[int] = None
+    conflictingProperties: Optional[list[str]] = None
 
 
 class Entity(Model):
@@ -60,12 +60,12 @@ class Entity(Model):
     creatorId: int
     createdAt: datetime
     currentVersion: CurrentVersion
-    conflict: str | None = None  # null, soft, hard
-    updatedAt: datetime | None = None
-    deletedAt: datetime | None = None
+    conflict: Optional[str] = None  # null, soft, hard
+    updatedAt: Optional[datetime] = None
+    deletedAt: Optional[datetime] = None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class URLs:
     _entity_name: str = "projects/{project_id}/datasets/{el_name}"
     _entities: str = f"{_entity_name}/entities"
@@ -97,17 +97,17 @@ class EntityService(Service):
     def __init__(
         self,
         session: Session,
-        default_project_id: int | None = None,
-        default_entity_list_name: str | None = None,
+        default_project_id: Optional[int] = None,
+        default_entity_list_name: Optional[str] = None,
         urls: URLs = None,
     ):
         self.urls: URLs = urls if urls is not None else URLs()
         self.session: Session = session
-        self.default_project_id: int | None = default_project_id
-        self.default_entity_list_name: str | None = default_entity_list_name
+        self.default_project_id: Optional[int] = default_project_id
+        self.default_entity_list_name: Optional[str] = default_entity_list_name
 
     def list(
-        self, entity_list_name: str | None = None, project_id: int | None = None
+        self, entity_list_name: Optional[str] = None, project_id: Optional[int] = None
     ) -> list[Entity]:
         """
         Read all Entity metadata.
@@ -138,9 +138,9 @@ class EntityService(Service):
         self,
         label: str,
         data: dict,
-        entity_list_name: str | None = None,
-        project_id: int | None = None,
-        uuid: str | None = None,
+        entity_list_name: Optional[str] = None,
+        project_id: Optional[int] = None,
+        uuid: Optional[str] = None,
     ) -> Entity:
         """
         Create an Entity.
@@ -179,10 +179,10 @@ class EntityService(Service):
     def create_many(
         self,
         data: Iterable[Mapping[str, Any]],
-        entity_list_name: str | None = None,
-        project_id: int | None = None,
-        create_source: str | None = None,
-        source_size: str | None = None,
+        entity_list_name: Optional[str] = None,
+        project_id: Optional[int] = None,
+        create_source: Optional[str] = None,
+        source_size: Optional[str] = None,
     ) -> bool:
         """
         Create one or more Entities in a single request.
@@ -253,12 +253,12 @@ class EntityService(Service):
     def update(
         self,
         uuid: str,
-        entity_list_name: str | None = None,
-        project_id: int | None = None,
-        label: str | None = None,
-        data: dict | None = None,
-        force: bool | None = None,
-        base_version: int | None = None,
+        entity_list_name: Optional[str] = None,
+        project_id: Optional[int] = None,
+        label: Optional[str] = None,
+        data: Optional[dict] = None,
+        force: Optional[bool] = None,
+        base_version: Optional[int] = None,
     ) -> Entity:
         """
         Update an Entity.
@@ -310,8 +310,8 @@ class EntityService(Service):
     def delete(
         self,
         uuid: str,
-        entity_list_name: str | None = None,
-        project_id: int | None = None,
+        entity_list_name: Optional[str] = None,
+        project_id: Optional[int] = None,
     ) -> bool:
         """
         Delete an Entity.
@@ -342,13 +342,13 @@ class EntityService(Service):
 
     def get_table(
         self,
-        entity_list_name: str | None = None,
-        project_id: int | None = None,
-        skip: int | None = None,
-        top: int | None = None,
-        count: bool | None = None,
-        filter: str | None = None,
-        select: str | None = None,
+        entity_list_name: Optional[str] = None,
+        project_id: Optional[int] = None,
+        skip: Optional[int] = None,
+        top: Optional[int] = None,
+        count: Optional[bool] = None,
+        filter: Optional[str] = None,
+        select: Optional[str] = None,
     ) -> dict:
         """
         Read Entity List data.
@@ -401,9 +401,9 @@ class EntityService(Service):
     def _prep_data_for_merge(
         source_data: Iterable[Mapping[str, Any]],
         target_data: Iterable[Mapping[str, Any]],
-        match_keys: Iterable[str] | None = None,
+        match_keys: Optional[Iterable[str]] = None,
         source_label_key: str = "label",
-        source_keys: Iterable[str] | None = None,
+        source_keys: Optional[Iterable[str]] = None,
     ) -> MergeActions:
         """
         Compare source and target data to identify rows to insert, update, or delete.
@@ -494,16 +494,16 @@ class EntityService(Service):
     def merge(
         self,
         data: Iterable[Mapping[str, Any]],
-        entity_list_name: str | None = None,
-        project_id: int | None = None,
-        match_keys: Iterable[str] | None = None,
+        entity_list_name: Optional[str] = None,
+        project_id: Optional[int] = None,
+        match_keys: Optional[Iterable[str]] = None,
         add_new_properties: bool = True,
         update_matched: bool = True,
         delete_not_matched: bool = False,
         source_label_key: str = "label",
-        source_keys: Iterable[str] | None = None,
-        create_source: str | None = None,
-        source_size: str | None = None,
+        source_keys: Optional[Iterable[str]] = None,
+        create_source: Optional[str] = None,
+        source_size: Optional[str] = None,
     ) -> MergeActions:
         """
         Update Entities in Central based on the provided data:

--- a/pyodk/_endpoints/entity_list_properties.py
+++ b/pyodk/_endpoints/entity_list_properties.py
@@ -6,6 +6,7 @@ from pyodk._endpoints.bases import Model, Service
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
+from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -17,7 +18,7 @@ class EntityListProperty(Model):
     forms: list[str]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class URLs:
     post: str = "projects/{project_id}/datasets/{entity_list_name}/properties"
 
@@ -33,20 +34,20 @@ class EntityListPropertyService(Service):
     def __init__(
         self,
         session: Session,
-        default_project_id: int | None = None,
-        default_entity_list_name: str | None = None,
+        default_project_id: Optional[int] = None,
+        default_entity_list_name: Optional[str] = None,
         urls: URLs = None,
     ):
         self.urls: URLs = urls if urls is not None else URLs()
         self.session: Session = session
-        self.default_project_id: int | None = default_project_id
-        self.default_entity_list_name: str | None = default_entity_list_name
+        self.default_project_id: Optional[int] = default_project_id
+        self.default_entity_list_name: Optional[str] = default_entity_list_name
 
     def create(
         self,
         name: str,
-        entity_list_name: str | None = None,
-        project_id: int | None = None,
+        entity_list_name: Optional[str] = None,
+        project_id: Optional[int] = None,
     ) -> bool:
         """
         Create an Entity List Property.

--- a/pyodk/_endpoints/entity_lists.py
+++ b/pyodk/_endpoints/entity_lists.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
 from pyodk._endpoints.bases import Model, Service
 from pyodk._endpoints.entity_list_properties import (
@@ -20,10 +20,10 @@ class EntityList(Model):
     projectId: int
     createdAt: datetime
     approvalRequired: bool
-    properties: list[EntityListProperty] | None = None
+    properties: Optional[list[EntityListProperty]] = None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class URLs:
     _entity_list = "projects/{project_id}/datasets"
     list: str = _entity_list
@@ -60,8 +60,8 @@ class EntityListService(Service):
     def __init__(
         self,
         session: Session,
-        default_project_id: int | None = None,
-        default_entity_list_name: str | None = None,
+        default_project_id: Optional[int] = None,
+        default_entity_list_name: Optional[str] = None,
         urls: URLs = None,
     ):
         self.urls: URLs = urls if urls is not None else URLs()
@@ -73,9 +73,9 @@ class EntityListService(Service):
         )
         self.add_property = self._property_service.create
 
-        self._default_project_id: int | None = None
+        self._default_project_id: Optional[int] = None
         self.default_project_id = default_project_id
-        self._default_entity_list_name: str | None = None
+        self._default_entity_list_name: Optional[str] = None
         self.default_entity_list_name = default_entity_list_name
 
     def _default_kw(self) -> dict[str, Any]:
@@ -85,7 +85,7 @@ class EntityListService(Service):
         }
 
     @property
-    def default_project_id(self) -> int | None:
+    def default_project_id(self) -> Optional[int]:
         return self._default_project_id
 
     @default_project_id.setter
@@ -94,7 +94,7 @@ class EntityListService(Service):
         self._property_service.default_project_id = v
 
     @property
-    def default_entity_list_name(self) -> str | None:
+    def default_entity_list_name(self) -> Optional[str]:
         return self._default_entity_list_name
 
     @default_entity_list_name.setter
@@ -102,7 +102,7 @@ class EntityListService(Service):
         self._default_entity_list_name = v
         self._property_service.default_entity_list_name = v
 
-    def list(self, project_id: int | None = None) -> list[EntityList]:
+    def list(self, project_id: Optional[int] = None) -> list[EntityList]:
         """
         Read all Entity List details.
 
@@ -126,8 +126,8 @@ class EntityListService(Service):
 
     def get(
         self,
-        entity_list_name: str | None = None,
-        project_id: int | None = None,
+        entity_list_name: Optional[str] = None,
+        project_id: Optional[int] = None,
     ) -> EntityList:
         """
         Read Entity List details.
@@ -158,9 +158,9 @@ class EntityListService(Service):
 
     def create(
         self,
-        approval_required: bool | None = False,
-        entity_list_name: str | None = None,
-        project_id: int | None = None,
+        approval_required: Optional[bool] = False,
+        entity_list_name: Optional[str] = None,
+        project_id: Optional[int] = None,
     ) -> EntityList:
         """
         Create an Entity List.

--- a/pyodk/_endpoints/form_assignments.py
+++ b/pyodk/_endpoints/form_assignments.py
@@ -5,11 +5,12 @@ from pyodk._endpoints.bases import Service
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
+from typing import Optional
 
 log = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class URLs:
     _form: str = "projects/{project_id}/forms/{form_id}"
     post: str = f"{_form}/assignments/{{role_id}}/{{user_id}}"
@@ -21,21 +22,21 @@ class FormAssignmentService(Service):
     def __init__(
         self,
         session: Session,
-        default_project_id: int | None = None,
-        default_form_id: str | None = None,
+        default_project_id: Optional[int] = None,
+        default_form_id: Optional[str] = None,
         urls: URLs = None,
     ):
         self.urls: URLs = urls if urls is not None else URLs()
         self.session: Session = session
-        self.default_project_id: int | None = default_project_id
-        self.default_form_id: str | None = default_form_id
+        self.default_project_id: Optional[int] = default_project_id
+        self.default_form_id: Optional[str] = default_form_id
 
     def assign(
         self,
         role_id: int,
         user_id: int,
-        form_id: str | None = None,
-        project_id: int | None = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
     ) -> bool:
         """
         Assign a user to a role for a form.

--- a/pyodk/_endpoints/form_draft_attachments.py
+++ b/pyodk/_endpoints/form_draft_attachments.py
@@ -3,6 +3,7 @@ import mimetypes
 from dataclasses import dataclass
 from datetime import datetime
 from os import PathLike
+from typing import Optional, Union
 
 from pyodk._endpoints.bases import Model, Service
 from pyodk._utils import validators as pv
@@ -22,7 +23,7 @@ class FormAttachment(Model):
     updatedAt: datetime  # When the file was created or deleted
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class URLs:
     _form: str = "projects/{project_id}/forms/{form_id}"
     post: str = f"{_form}/draft/attachments/{{fname}}"
@@ -34,21 +35,21 @@ class FormDraftAttachmentService(Service):
     def __init__(
         self,
         session: Session,
-        default_project_id: int | None = None,
-        default_form_id: str | None = None,
+        default_project_id: Optional[int] = None,
+        default_form_id: Optional[str] = None,
         urls: URLs = None,
     ):
         self.urls: URLs = urls if urls is not None else URLs()
         self.session: Session = session
-        self.default_project_id: int | None = default_project_id
-        self.default_form_id: str | None = default_form_id
+        self.default_project_id: Optional[int] = default_project_id
+        self.default_form_id: Optional[str] = default_form_id
 
     def upload(
         self,
-        file_path: PathLike | str,
-        file_name: str | None = None,
-        form_id: str | None = None,
-        project_id: int | None = None,
+        file_path: Union[PathLike, str],
+        file_name: Optional[str] = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
     ) -> bool:
         """
         Upload a Form Draft Attachment.

--- a/pyodk/_endpoints/form_drafts.py
+++ b/pyodk/_endpoints/form_drafts.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import dataclass
 from io import BytesIO
 from os import PathLike
+from typing import Optional, Union
 from zipfile import is_zipfile
 
 from pyodk._endpoints.bases import Service
@@ -40,8 +41,8 @@ def is_xls_file(buf: bytes) -> bool:
 
 
 def get_definition_data(
-    definition: PathLike | str | bytes | None,
-) -> (bytes, str, str | None):
+    definition: Optional[Union[PathLike, str, bytes]],
+) -> tuple[bytes, str, Optional[str]]:
     """
     Get the form definition data from a path or bytes.
 
@@ -58,7 +59,7 @@ def get_definition_data(
     ):
         content_type = CONTENT_TYPES[".xml"]
         definition_data = definition.encode("utf-8")
-    elif isinstance(definition, str | PathLike):
+    elif isinstance(definition, (str, PathLike)):
         file_path = pv.validate_file_path(definition)
         file_path_stem = file_path.stem
         definition_data = file_path.read_bytes()
@@ -82,7 +83,7 @@ def get_definition_data(
     return definition_data, content_type, file_path_stem
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class URLs:
     _form: str = "projects/{project_id}/forms/{form_id}"
     post: str = f"{_form}/draft"
@@ -95,22 +96,22 @@ class FormDraftService(Service):
     def __init__(
         self,
         session: Session,
-        default_project_id: int | None = None,
-        default_form_id: str | None = None,
+        default_project_id: Optional[int] = None,
+        default_form_id: Optional[str] = None,
         urls: URLs = None,
     ):
         self.urls: URLs = urls if urls is not None else URLs()
         self.session: Session = session
-        self.default_project_id: int | None = default_project_id
-        self.default_form_id: str | None = default_form_id
+        self.default_project_id: Optional[int] = default_project_id
+        self.default_form_id: Optional[str] = default_form_id
 
     def _prep_form_post(
         self,
-        definition: PathLike | str | bytes | None = None,
-        ignore_warnings: bool | None = True,
-        form_id: str | None = None,
-        project_id: int | None = None,
-    ) -> (str, str, dict, dict, bytes | None):
+        definition: Optional[Union[PathLike, str, bytes]] = None,
+        ignore_warnings: Optional[bool] = True,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
+    ) -> tuple[str, str, dict, dict, Optional[bytes]]:
         """
         Prepare / validate input arguments for POSTing a new form definition or version.
 
@@ -151,10 +152,10 @@ class FormDraftService(Service):
 
     def create(
         self,
-        definition: PathLike | str | bytes | None = None,
-        ignore_warnings: bool | None = True,
-        form_id: str | None = None,
-        project_id: int | None = None,
+        definition: Optional[Union[PathLike, str, bytes]] = None,
+        ignore_warnings: Optional[bool] = True,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
     ) -> bool:
         """
         Create a Form Draft.
@@ -184,9 +185,9 @@ class FormDraftService(Service):
 
     def publish(
         self,
-        form_id: str | None = None,
-        project_id: int | None = None,
-        version: str | None = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
+        version: Optional[str] = None,
     ) -> bool:
         """
         Publish a Form Draft.

--- a/pyodk/_endpoints/forms.py
+++ b/pyodk/_endpoints/forms.py
@@ -3,7 +3,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from os import PathLike
-from typing import Any
+from typing import Any, Optional, Union
 
 from pyodk._endpoints.bases import Model, Service
 from pyodk._endpoints.form_draft_attachments import FormDraftAttachmentService
@@ -25,14 +25,14 @@ class Form(Model):
     hash: str
     state: str  # open, closing, closed
     createdAt: datetime
-    name: str | None  # Null if Central couldn't parse the XForm title, or it was blank.
-    enketoId: str | None  # Null if Enketo not being used with Central.
-    keyId: int | None
-    updatedAt: datetime | None
-    publishedAt: datetime | None
+    name: Optional[str]  # Null if Central couldn't parse the XForm title, or it was blank.
+    enketoId: Optional[str]  # Null if Enketo not being used with Central.
+    keyId: Optional[int]
+    updatedAt: Optional[datetime]
+    publishedAt: Optional[datetime]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class URLs:
     forms: str = "projects/{project_id}/forms"
     get: str = f"{forms}/{{form_id}}"
@@ -55,14 +55,14 @@ class FormService(Service):
     def __init__(
         self,
         session: Session,
-        default_project_id: int | None = None,
-        default_form_id: str | None = None,
+        default_project_id: Optional[int] = None,
+        default_form_id: Optional[str] = None,
         urls: URLs = None,
     ):
         self.urls: URLs = urls if urls is not None else URLs()
         self.session: Session = session
-        self.default_project_id: int | None = default_project_id
-        self.default_form_id: str | None = default_form_id
+        self.default_project_id: Optional[int] = default_project_id
+        self.default_form_id: Optional[str] = default_form_id
 
     def _default_kw(self) -> dict[str, Any]:
         return {
@@ -70,7 +70,7 @@ class FormService(Service):
             "default_form_id": self.default_form_id,
         }
 
-    def list(self, project_id: int | None = None) -> list[Form]:
+    def list(self, project_id: Optional[int] = None) -> list[Form]:
         """
         Read all Form details.
 
@@ -95,7 +95,7 @@ class FormService(Service):
     def get(
         self,
         form_id: str,
-        project_id: int | None = None,
+        project_id: Optional[int] = None,
     ) -> Form:
         """
         Read Form details.
@@ -122,11 +122,11 @@ class FormService(Service):
 
     def create(
         self,
-        definition: PathLike | str | bytes,
-        attachments: Iterable[PathLike | str] | None = None,
-        ignore_warnings: bool | None = True,
-        form_id: str | None = None,
-        project_id: int | None = None,
+        definition: Union[PathLike, str, bytes],
+        attachments: Optional[Iterable[Union[PathLike, str]]] = None,
+        ignore_warnings: Optional[bool] = True,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
     ) -> Form:
         """
         Create a form.
@@ -179,10 +179,10 @@ class FormService(Service):
     def update(
         self,
         form_id: str,
-        project_id: int | None = None,
-        definition: PathLike | str | bytes | None = None,
-        attachments: Iterable[PathLike | str] | None = None,
-        version_updater: Callable[[str], str] | None = None,
+        project_id: Optional[int] = None,
+        definition: Optional[Union[PathLike, str, bytes]] = None,
+        attachments: Optional[Iterable[Union[PathLike, str]]] = None,
+        version_updater: Optional[Callable[[str], str]] = None,
     ) -> None:
         """
         Update an existing Form. Must specify definition, attachments or both.

--- a/pyodk/_endpoints/project_app_users.py
+++ b/pyodk/_endpoints/project_app_users.py
@@ -6,6 +6,7 @@ from pyodk._endpoints.bases import Model, Service
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
+from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -15,13 +16,13 @@ class ProjectAppUser(Model):
     id: int
     displayName: str
     createdAt: datetime
-    type: str | None  # user, field_key, public_link, singleUse
-    token: str | None
-    updatedAt: datetime | None
-    deletedAt: datetime | None
+    type: Optional[str]  # user, field_key, public_link, singleUse
+    token: Optional[str]
+    updatedAt: Optional[datetime]
+    deletedAt: Optional[datetime]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class URLs:
     list: str = "projects/{project_id}/app-users"
     post: str = "projects/{project_id}/app-users"
@@ -37,16 +38,16 @@ class ProjectAppUserService(Service):
     def __init__(
         self,
         session: Session,
-        default_project_id: int | None = None,
+        default_project_id: Optional[int] = None,
         urls: URLs = None,
     ):
         self.urls: URLs = urls if urls is not None else URLs()
         self.session: Session = session
-        self.default_project_id: int | None = default_project_id
+        self.default_project_id: Optional[int] = default_project_id
 
     def list(
         self,
-        project_id: int | None = None,
+        project_id: Optional[int] = None,
     ) -> list[ProjectAppUser]:
         """
         Read all ProjectAppUser details.
@@ -70,7 +71,7 @@ class ProjectAppUserService(Service):
     def create(
         self,
         display_name: str,
-        project_id: int | None = None,
+        project_id: Optional[int] = None,
     ) -> ProjectAppUser:
         """
         Create a ProjectAppUser.

--- a/pyodk/_endpoints/projects.py
+++ b/pyodk/_endpoints/projects.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional, Union
 
 from pyodk._endpoints.bases import Model, Service
 from pyodk._endpoints.form_assignments import FormAssignmentService
@@ -18,17 +18,17 @@ class Project(Model):
     id: int
     name: str
     createdAt: datetime
-    description: str | None = None
-    archived: bool | None = None
-    keyId: int | None = None
-    appUsers: int | None = None
-    forms: int | None = None
-    lastSubmission: str | None = None
-    updatedAt: datetime | None = None
-    deletedAt: datetime | None = None
+    description: Optional[str] = None
+    archived: Optional[bool] = None
+    keyId: Optional[int] = None
+    appUsers: Optional[int] = None
+    forms: Optional[int] = None
+    lastSubmission: Optional[str] = None
+    updatedAt: Optional[datetime] = None
+    deletedAt: Optional[datetime] = None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class URLs:
     list: str = "projects"
     get: str = "projects/{project_id}"
@@ -53,12 +53,12 @@ class ProjectService(Service):
     def __init__(
         self,
         session: Session,
-        default_project_id: int | None = None,
+        default_project_id: Optional[int] = None,
         urls: URLs = None,
     ):
         self.urls: URLs = urls if urls is not None else URLs()
         self.session: Session = session
-        self.default_project_id: int | None = default_project_id
+        self.default_project_id: Optional[int] = default_project_id
 
     def _default_kw(self) -> dict[str, Any]:
         return {
@@ -79,7 +79,7 @@ class ProjectService(Service):
         data = response.json()
         return [Project(**r) for r in data]
 
-    def get(self, project_id: int | None = None) -> Project:
+    def get(self, project_id: Optional[int] = None) -> Project:
         """
         Read all Project details.
 
@@ -104,8 +104,8 @@ class ProjectService(Service):
     def create_app_users(
         self,
         display_names: Iterable[str],
-        forms: Iterable[str] | None = None,
-        project_id: int | None = None,
+        forms: Optional[Iterable[str]] = None,
+        project_id: Optional[int] = None,
     ) -> Iterable[ProjectAppUser]:
         """
         Create new project app users and optionally assign forms to them.

--- a/pyodk/_endpoints/submission_attachments.py
+++ b/pyodk/_endpoints/submission_attachments.py
@@ -2,6 +2,7 @@ import logging
 import mimetypes
 from dataclasses import dataclass
 from os import PathLike
+from typing import Optional, Union
 
 from pyodk._endpoints.bases import Model, Service
 from pyodk._utils import validators as pv
@@ -16,7 +17,7 @@ class SubmissionAttachment(Model):
     exists: bool
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class URLs:
     _submission: str = "projects/{project_id}/forms/{form_id}/submissions/{instance_id}"
     list: str = f"{_submission}/attachments"
@@ -35,22 +36,22 @@ class SubmissionAttachmentService(Service):
     def __init__(
         self,
         session: Session,
-        default_project_id: int | None = None,
-        default_form_id: str | None = None,
-        default_instance_id: str | None = None,
+        default_project_id: Optional[int] = None,
+        default_form_id: Optional[str] = None,
+        default_instance_id: Optional[str] = None,
         urls: URLs = None,
     ):
         self.urls: URLs = urls if urls is not None else URLs()
         self.session: Session = session
-        self.default_project_id: int | None = default_project_id
-        self.default_form_id: str | None = default_form_id
-        self.default_instance_id: str | None = default_instance_id
+        self.default_project_id: Optional[int] = default_project_id
+        self.default_form_id: Optional[str] = default_form_id
+        self.default_instance_id: Optional[str] = default_instance_id
 
     def list(
         self,
-        form_id: str | None = None,
-        project_id: int | None = None,
-        instance_id: str | None = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
+        instance_id: Optional[str] = None,
     ) -> list[SubmissionAttachment]:
         """
         Read all Submission Attachment details.
@@ -79,11 +80,11 @@ class SubmissionAttachmentService(Service):
 
     def upload(
         self,
-        file_path: PathLike | str,
-        file_name: str | None = None,
-        project_id: int | None = None,
-        form_id: str | None = None,
-        instance_id: str | None = None,
+        file_path: Union[PathLike, str],
+        file_name: Optional[str] = None,
+        project_id: Optional[int] = None,
+        form_id: Optional[str] = None,
+        instance_id: Optional[str] = None,
     ) -> bool:
         """
         Upload a Submission Attachment.

--- a/pyodk/_endpoints/submissions.py
+++ b/pyodk/_endpoints/submissions.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from os import PathLike
-from typing import Any
+from typing import Any, Optional, Union
 
 from pyodk._endpoints.bases import Model, Service
 from pyodk._endpoints.comments import Comment, CommentService
@@ -22,16 +22,16 @@ class Submission(Model):
     instanceId: str
     submitterId: int
     createdAt: datetime
-    deviceId: str | None = None
+    deviceId: Optional[str] = None
     # null, edited, hasIssues, rejected, approved
-    reviewState: str | None = None
-    userAgent: str | None = None
-    instanceName: str | None = None
-    updatedAt: datetime | None = None
-    attachments: list[SubmissionAttachment] | None = None
+    reviewState: Optional[str] = None
+    userAgent: Optional[str] = None
+    instanceName: Optional[str] = None
+    updatedAt: Optional[datetime] = None
+    attachments: Optional[list[SubmissionAttachment]] = None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class URLs:
     _form: str = "projects/{project_id}/forms/{form_id}"
     list: str = f"{_form}/submissions"
@@ -59,14 +59,14 @@ class SubmissionService(Service):
     def __init__(
         self,
         session: Session,
-        default_project_id: int | None = None,
-        default_form_id: str | None = None,
+        default_project_id: Optional[int] = None,
+        default_form_id: Optional[str] = None,
         urls: URLs = None,
     ):
         self.urls: URLs = urls if urls is not None else URLs()
         self.session: Session = session
-        self.default_project_id: int | None = default_project_id
-        self.default_form_id: str | None = default_form_id
+        self.default_project_id: Optional[int] = default_project_id
+        self.default_form_id: Optional[str] = default_form_id
 
     def _default_kw(self) -> dict[str, Any]:
         return {
@@ -75,7 +75,7 @@ class SubmissionService(Service):
         }
 
     def list(
-        self, form_id: str | None = None, project_id: int | None = None
+        self, form_id: Optional[str] = None, project_id: Optional[int] = None
     ) -> list[Submission]:
         """
         Read all Submission metadata.
@@ -103,8 +103,8 @@ class SubmissionService(Service):
     def get(
         self,
         instance_id: str,
-        form_id: str | None = None,
-        project_id: int | None = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
     ) -> Submission:
         """
         Read Submission metadata.
@@ -135,16 +135,16 @@ class SubmissionService(Service):
 
     def get_table(
         self,
-        form_id: str | None = None,
-        project_id: int | None = None,
-        table_name: str | None = "Submissions",
-        skip: int | None = None,
-        top: int | None = None,
-        count: bool | None = None,
-        wkt: bool | None = None,
-        filter: str | None = None,
-        expand: str | None = None,
-        select: str | None = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
+        table_name: Optional[str] = "Submissions",
+        skip: Optional[int] = None,
+        top: Optional[int] = None,
+        count: Optional[bool] = None,
+        wkt: Optional[bool] = None,
+        filter: Optional[str] = None,
+        expand: Optional[str] = None,
+        select: Optional[str] = None,
     ) -> dict:
         """
         Read Submission data.
@@ -202,11 +202,11 @@ class SubmissionService(Service):
     def create(
         self,
         xml: str,
-        form_id: str | None = None,
-        project_id: int | None = None,
-        device_id: str | None = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
+        device_id: Optional[str] = None,
         encoding: str = "utf-8",
-        attachments: Iterable[PathLike | str] | None = None,
+        attachments: Optional[Iterable[Union[PathLike, str]]] = None,
     ) -> Submission:
         """
         Create a Submission.
@@ -291,8 +291,8 @@ class SubmissionService(Service):
         self,
         instance_id: str,
         xml: str,
-        form_id: str | None = None,
-        project_id: int | None = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
         encoding: str = "utf-8",
     ) -> Submission:
         """
@@ -328,8 +328,8 @@ class SubmissionService(Service):
         self,
         instance_id: str,
         review_state: str,
-        form_id: str | None = None,
-        project_id: int | None = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
     ) -> Submission:
         """
         Update Submission metadata.
@@ -365,9 +365,9 @@ class SubmissionService(Service):
         self,
         instance_id: str,
         xml: str,
-        form_id: str | None = None,
-        project_id: int | None = None,
-        comment: str | None = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
+        comment: Optional[str] = None,
         encoding: str = "utf-8",
     ) -> None:
         """
@@ -406,9 +406,9 @@ class SubmissionService(Service):
         self,
         instance_id: str,
         review_state: str,
-        form_id: str | None = None,
-        project_id: int | None = None,
-        comment: str | None = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
+        comment: Optional[str] = None,
     ) -> None:
         """
         Update Submission metadata and optionally comment on it.
@@ -427,8 +427,8 @@ class SubmissionService(Service):
     def list_comments(
         self,
         instance_id: str,
-        form_id: str | None = None,
-        project_id: int | None = None,
+        form_id: Optional[str] = None,
+        project_id: Optional[int] = None,
     ) -> Iterable[Comment]:
         """
         Read all Comment details.
@@ -447,8 +447,8 @@ class SubmissionService(Service):
         self,
         instance_id: str,
         comment: str,
-        project_id: int | None = None,
-        form_id: str | None = None,
+        project_id: Optional[int] = None,
+        form_id: Optional[str] = None,
     ) -> Comment:
         """
         Create a Comment.

--- a/pyodk/_utils/config.py
+++ b/pyodk/_utils/config.py
@@ -2,6 +2,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Optional
 
 import toml
 
@@ -20,7 +21,7 @@ class CentralConfig:
     base_url: str
     username: str
     password: str = field(repr=False)
-    default_project_id: int | None = None
+    default_project_id: Optional[int] = None
 
     def validate(self):
         for key in ["base_url", "username", "password"]:  # Mandatory keys.
@@ -59,11 +60,11 @@ def get_path(path: str, env_key: str) -> Path:
     return defaults[env_key]
 
 
-def get_config_path(config_path: str | None = None) -> Path:
+def get_config_path(config_path: Optional[str] = None) -> Path:
     return get_path(path=config_path, env_key="PYODK_CONFIG_FILE")
 
 
-def get_cache_path(cache_path: str | None = None) -> Path:
+def get_cache_path(cache_path: Optional[str] = None) -> Path:
     return get_path(path=cache_path, env_key="PYODK_CACHE_FILE")
 
 
@@ -80,7 +81,7 @@ def read_toml(path: Path) -> dict:
         raise pyodk_err from err
 
 
-def read_config(config_path: str | None = None) -> Config:
+def read_config(config_path: Optional[str] = None) -> Config:
     """
     Read the config file.
     """
@@ -89,7 +90,7 @@ def read_config(config_path: str | None = None) -> Config:
     return objectify_config(config_data=file_data)
 
 
-def read_cache_token(cache_path: str | None = None) -> str:
+def read_cache_token(cache_path: Optional[str] = None) -> str:
     """
     Read the "token" key from the cache file.
     """
@@ -102,7 +103,7 @@ def read_cache_token(cache_path: str | None = None) -> str:
     return file_data["token"]
 
 
-def write_cache(key: str, value: str, cache_path: str | None = None) -> None:
+def write_cache(key: str, value: str, cache_path: Optional[str] = None) -> None:
     """
     Append or overwrite the given key/value pair to the cache file.
     """
@@ -116,7 +117,7 @@ def write_cache(key: str, value: str, cache_path: str | None = None) -> None:
         toml.dump(file_data, outfile)
 
 
-def delete_cache(cache_path: str | None = None) -> None:
+def delete_cache(cache_path: Optional[str] = None) -> None:
     """
     Delete the cache file, if it exists.
     """

--- a/pyodk/_utils/validators.py
+++ b/pyodk/_utils/validators.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from os import PathLike
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 
 from pydantic.v1 import validators as v
 from pydantic.v1.errors import PydanticTypeError, PydanticValueError
@@ -98,7 +98,7 @@ def validate_dict(*args: dict, key: str) -> int:
     )
 
 
-def validate_file_path(*args: PathLike | str, key: str = "file_path") -> Path:
+def validate_file_path(*args: Union[PathLike, str], key: str = "file_path") -> Path:
     def validate_fp(f):
         p = v.path_validator(f)
         return v.path_exists_validator(p)

--- a/pyodk/client.py
+++ b/pyodk/client.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import Optional
 
 from pyodk._endpoints.comments import CommentService
 from pyodk._endpoints.entities import EntityService
@@ -30,14 +31,14 @@ class Client:
 
     def __init__(
         self,
-        config_path: str | None = None,
-        cache_path: str | None = None,
-        project_id: int | None = None,
-        session: Session | None = None,
-        api_version: str | None = "v1",
+        config_path: Optional[str] = None,
+        cache_path: Optional[str] = None,
+        project_id: Optional[int] = None,
+        session: Optional[Session] = None,
+        api_version: Optional[str] = "v1",
     ) -> None:
         self.config: config.Config = config.read_config(config_path=config_path)
-        self._project_id: int | None = project_id
+        self._project_id: Optional[int] = project_id
         if session is None:
             session = Session(
                 base_url=self.config.central.base_url,
@@ -77,7 +78,7 @@ class Client:
         )
 
     @property
-    def project_id(self) -> int | None:
+    def project_id(self) -> Optional[int]:
         if self._project_id is None:
             return self.config.central.default_project_id
         else:

--- a/pyodk/errors.py
+++ b/pyodk/errors.py
@@ -1,10 +1,11 @@
 from requests import Response
+from typing import Union
 
 
 class PyODKError(Exception):
     """An error raised by pyodk."""
 
-    def is_central_error(self, code: float | str) -> bool:
+    def is_central_error(self, code: Union[float, str]) -> bool:
         """
         Does the PyODK error represent a Central error with the specified code?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "The official Python library for ODK 🐍"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = [
     "requests==2.32.3",  # HTTP with Central
     "toml==0.10.2",      # Configuration files
@@ -43,7 +43,7 @@ exclude = ["docs", "tests"]
 
 [tool.ruff]
 line-length = 90
-target-version = "py310"
+target-version = "py39"
 fix = true
 show-fixes = true
 output-format = "full"

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.12
+python-3.9


### PR DESCRIPTION
## Summary
- lower minimum Python to 3.9
- adjust ruff target version
- update runtime and CI for 3.9
- replace PEP604 union types with `Optional` and `Union`
- drop dataclass slots for Python 3.9 compatibility
- document Python 3.9 support

## Testing
- `python -m unittest --verbose` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_b_6864f35412ec8330add5e42627372cd9